### PR TITLE
Expand error calculations for geom_errorbox

### DIFF
--- a/R/draw_reference_box.R
+++ b/R/draw_reference_box.R
@@ -13,7 +13,7 @@
 #' @param y A character string specifying the name of the y variable
 #' @param fill The fill color of the reference box. Defaults to "white"
 #' @param colour The border color of the reference box. Defaults to "#028760"
-#' @param fun.errorbar A character string indicating the method to calculate the error bar. It can be either "sd" for standard deviation or "se" for standard error. Defaults to "sd"
+#' @param fun.errorbar Error calculation method ("sd", "se", "ci" or a custom function). Defaults to "sd"
 #' @param na.rm A logical value indicating whether NA values should be stripped before the computation proceeds. Defaults to FALSE
 #' @param ... Other arguments passed on to \code{geom_rect()}
 #' @return A ggplot object with the reference box added

--- a/R/geom_errorbox.R
+++ b/R/geom_errorbox.R
@@ -24,7 +24,7 @@ StatErrorbox <- ggplot2::ggproto("StatErrorbox", ggplot2::Stat,
 #'
 #' This function draws a rectangular error box centered at the mean of x and y coordinates,
 #' with dimensions determined by a specified error calculation method (standard deviation,
-#' standard error, confidence interval, etc.).
+#' standard error, 95% confidence interval, etc.).
 #'
 #' @param mapping Set of aesthetic mappings, usually created with `aes()`
 #' @param data The data to be displayed. If NULL, the default, the data is inherited from the plot data
@@ -45,7 +45,7 @@ StatErrorbox <- ggplot2::ggproto("StatErrorbox", ggplot2::Stat,
 #' \itemize{
 #'   \item "sd": Standard deviation
 #'   \item "se": Standard error (standard deviation divided by square root of the number of observations)
-#'   \item "ci": 95\% confidence interval
+#'   \item "ci": 95\% confidence interval (based on the t-distribution)
 #'   \item custom function: You can provide your own error calculation function
 #' }
 #'
@@ -58,13 +58,17 @@ StatErrorbox <- ggplot2::ggproto("StatErrorbox", ggplot2::Stat,
 #' p + geom_point() +
 #'   geom_errorbox(fill = "white", color = "blue", alpha = 0.3)
 #'
+#' # Using standard deviation (default)
+#' p + geom_point() +
+#'   geom_errorbox(fill = "white", color = "red", alpha = 0.2)
+#'
 #' # Using standard error
 #' p + geom_point() +
-#'   geom_errorbox(fill = "white", color = "red", alpha = 0.2, fun.errorbar = "sd")
-#'
-#' # Using confidence interval
-#' p + geom_point() +
 #'   geom_errorbox(fill = "white", color = "green", alpha = 0.2, fun.errorbar = "se")
+#'
+#' # Using 95% confidence interval
+#' p + geom_point() +
+#'   geom_errorbox(fill = "white", color = "purple", alpha = 0.2, fun.errorbar = "ci")
 #'
 #' # Error boxes by group
 #' p <- ggplot(mtcars, aes(wt, mpg, color = factor(cyl)))

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -18,23 +18,40 @@ se <- function(x, na.rm = FALSE) {
 
 
 
-#' Calculate SD/SE for Errorbar
+#' Calculate Error for Errorbars
 #'
-#' This function calculates either the standard deviation or the standard error of a numeric vector, depending on the specified method.
+#' This function calculates an error value (standard deviation, standard error,
+#' 95% confidence interval, or a user-supplied function) for a numeric vector.
 #'
 #' @param x A numeric vector
-#' @param fun.errorbar A character string indicating the method to calculate the error bar. It can be either "sd" for standard deviation or "se" for standard error. Defaults to "sd"
-#' @param na.rm A logical value indicating whether NA values should be stripped before the computation proceeds. Defaults to FALSE
-#' @return The calculated error bar (either standard deviation or standard error) of the input vector
+#' @param fun.errorbar Either a character string specifying the method to
+#'   calculate the error ("sd", "se", or "ci"), or a function that accepts
+#'   a numeric vector and returns a single numeric value.
+#' @param na.rm A logical value indicating whether \code{NA} values should be
+#'   removed before computation. Defaults to \code{FALSE}.
+#' @return The calculated error value of the input vector
 #' @examples
 #' calc_error(c(1, 2, 3, 4, 5))
 #' calc_error(c(1, 2, 3, 4, 5, NA), fun.errorbar = "se", na.rm = TRUE)
+#' calc_error(c(1, 2, 3, 4, 5), fun.errorbar = "ci")
+#' calc_error(c(1, 2, 3, 4, 5), fun.errorbar = function(x) max(x) - min(x))
 #' @export
 calc_error <- function(x, fun.errorbar = "sd", na.rm = FALSE) {
-  if (fun.errorbar == "sd") {
-    stats::sd(x, na.rm = na.rm)
-  } else if (fun.errorbar == "se") {
-    se(x, na.rm = na.rm)
+  if (is.character(fun.errorbar)) {
+    if (fun.errorbar == "sd") {
+      stats::sd(x, na.rm = na.rm)
+    } else if (fun.errorbar == "se") {
+      se(x, na.rm = na.rm)
+    } else if (fun.errorbar == "ci") {
+      n <- if (na.rm) sum(!is.na(x)) else length(x)
+      se(x, na.rm = na.rm) * stats::qt(0.975, df = n - 1)
+    } else {
+      stop("Unsupported fun.errorbar: ", fun.errorbar)
+    }
+  } else if (is.function(fun.errorbar)) {
+    fun.errorbar(x)
+  } else {
+    stop("fun.errorbar must be a character string or function")
   }
 }
 

--- a/man/calc_error.Rd
+++ b/man/calc_error.Rd
@@ -2,24 +2,26 @@
 % Please edit documentation in R/utilities.R
 \name{calc_error}
 \alias{calc_error}
-\title{Calculate SD/SE for Errorbar}
+\title{Calculate Error for Errorbars}
 \usage{
 calc_error(x, fun.errorbar = "sd", na.rm = FALSE)
 }
 \arguments{
 \item{x}{A numeric vector}
 
-\item{fun.errorbar}{A character string indicating the method to calculate the error bar. It can be either "sd" for standard deviation or "se" for standard error. Defaults to "sd"}
+\item{fun.errorbar}{Either a character string specifying the method to calculate the error ("sd", "se", or "ci"), or a function that returns a numeric value.}
 
 \item{na.rm}{A logical value indicating whether NA values should be stripped before the computation proceeds. Defaults to FALSE}
 }
 \value{
-The calculated error bar (either standard deviation or standard error) of the input vector
+The calculated error value of the input vector
 }
 \description{
-This function calculates either the standard deviation or the standard error of a numeric vector, depending on the specified method.
+This function calculates an error value (standard deviation, standard error, 95\% confidence interval, or a user-supplied function) for a numeric vector.
 }
 \examples{
 calc_error(c(1, 2, 3, 4, 5))
 calc_error(c(1, 2, 3, 4, 5, NA), fun.errorbar = "se", na.rm = TRUE)
+calc_error(c(1, 2, 3, 4, 5), fun.errorbar = "ci")
+calc_error(c(1, 2, 3, 4, 5), fun.errorbar = function(x) max(x) - min(x))
 }

--- a/man/draw_reference_box.Rd
+++ b/man/draw_reference_box.Rd
@@ -29,7 +29,7 @@ draw_reference_box(
 
 \item{colour}{The border color of the reference box. Defaults to "#028760"}
 
-\item{fun.errorbar}{A character string indicating the method to calculate the error bar. It can be either "sd" for standard deviation or "se" for standard error. Defaults to "sd"}
+\item{fun.errorbar}{Error calculation method ("sd", "se", "ci" or a custom function). Defaults to "sd"}
 
 \item{na.rm}{A logical value indicating whether NA values should be stripped before the computation proceeds. Defaults to FALSE}
 

--- a/man/geom_errorbox.Rd
+++ b/man/geom_errorbox.Rd
@@ -41,7 +41,7 @@ A ggplot2 layer
 \description{
 This function draws a rectangular error box centered at the mean of x and y coordinates,
 with dimensions determined by a specified error calculation method (standard deviation,
-standard error, confidence interval, etc.).
+standard error, 95\% confidence interval, etc.).
 }
 \details{
 The error box is drawn as a rectangle spanning from xmin to xmax and ymin to ymax,
@@ -52,7 +52,7 @@ Error calculation methods:
 \itemize{
 \item "sd": Standard deviation
 \item "se": Standard error (standard deviation divided by square root of the number of observations)
-\item "ci": 95\\% confidence interval
+\item "ci": 95\\% confidence interval (based on the t-distribution)
 \item custom function: You can provide your own error calculation function
 }
 }
@@ -63,13 +63,17 @@ p <- ggplot(mtcars, aes(wt, mpg))
 p + geom_point() +
   geom_errorbox(fill = "white", color = "blue", alpha = 0.3)
 
+# Using standard deviation (default)
+p + geom_point() +
+  geom_errorbox(fill = "white", color = "red", alpha = 0.2)
+
 # Using standard error
 p + geom_point() +
-  geom_errorbox(fill = "white", color = "red", alpha = 0.2, fun.errorbar = "sd")
-
-# Using confidence interval
-p + geom_point() +
   geom_errorbox(fill = "white", color = "green", alpha = 0.2, fun.errorbar = "se")
+
+# Using 95\% confidence interval
+p + geom_point() +
+  geom_errorbox(fill = "white", color = "purple", alpha = 0.2, fun.errorbar = "ci")
 
 # Error boxes by group
 p <- ggplot(mtcars, aes(wt, mpg, color = factor(cyl)))


### PR DESCRIPTION
## Summary
- support 95% confidence intervals and custom functions in `calc_error`
- document and exemplify new error options for `geom_errorbox` and related helpers

------
https://chatgpt.com/codex/tasks/task_e_68a8096874848327a4e5398fb7332ccb