### PR TITLE
Reject zero error bar tip size

### DIFF
--- a/R/errorbarbGrob.R
+++ b/R/errorbarbGrob.R
@@ -127,8 +127,8 @@ create_errorbarb <- function(x, y, height, width, errorbar_tip_size) {
   if (width <= 0) {
     rlang::abort("`width` must be larger than zero.")
   }
-  if (errorbar_tip_size < 0) {
-    rlang::abort("`errorbar_tip_size` must be larger than zero.")
+  if (errorbar_tip_size <= 0) {
+    rlang::abort("`errorbar_tip_size` must be strictly positive.")
   }
   # calculate coordination of errorbarb
   data.frame(


### PR DESCRIPTION
## Summary
- Reject zero-length error bar tips in `create_errorbarb`
- Clarify error message to require strictly positive `errorbar_tip_size`

------
https://chatgpt.com/codex/tasks/task_e_68a8176d85cc832795434c0f7696ad5b