### PR TITLE
Pass na.rm to errorbarbGrob

### DIFF
--- a/R/geom_errorbarb.R
+++ b/R/geom_errorbarb.R
@@ -80,6 +80,7 @@ Geomerrorbarb <- ggproto("Geomerrorbarb", Geom,
       coord$y,
       default.units = "native",
       fun.errorbar = fun.errorbar,
+      na.rm = na.rm,
       errorbar_tip_size = unit(errorbar_tip_size, "cm"),
       gp = grid::gpar(
         col = alpha(coord$colour, coord$alpha),


### PR DESCRIPTION
## Summary
- Forward `na.rm` to `errorbarbGrob` inside `Geomerrorbarb` so missing values are handled properly.

## Testing
- `R CMD build .` *(fails: command not found: R)*
- `apt-get update` *(fails: repository is not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a8176fd4108327b8675dba98880714