### PR TITLE
Add testthat tests for utility functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,3 +30,4 @@ Suggests:
     knitr (>= 1.30),
     rmarkdown (>= 2.5)
 RoxygenNote: 7.3.2
+Config/testthat/edition: 3

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(ggbothbar)
+
+test_check("ggbothbar")

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -1,0 +1,19 @@
+test_that("se computes standard error", {
+  x <- 1:5
+  expect_equal(se(x), stats::sd(x) / sqrt(length(x)))
+})
+
+test_that("se handles na.rm", {
+  x <- c(1, 2, 3, NA, 4, 5)
+  expect_equal(se(x, na.rm = TRUE), stats::sd(x, na.rm = TRUE) / sqrt(sum(!is.na(x))))
+})
+
+test_that("calc_error uses sd by default", {
+  x <- 1:5
+  expect_equal(calc_error(x), stats::sd(x))
+})
+
+test_that("calc_error uses se when specified", {
+  x <- 1:5
+  expect_equal(calc_error(x, fun.errorbar = "se"), se(x))
+})


### PR DESCRIPTION
## Summary
- configure testthat edition 3
- add basic tests for `se` and `calc_error`

------
https://chatgpt.com/codex/tasks/task_e_68a81c723da0832783d04b42415c5675