### PR TITLE
Allow zero errorbar widths

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ggbothbar
 Type: Package
 Title: Visualise isotopic abundance data.
-Version: 1.0.0
+Version: 1.0.1
 Authors@R: c(
     person("Hiedehito", "Okada", , "hidefungi@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-3210-2736"))

--- a/R/errorbarbGrob.R
+++ b/R/errorbarbGrob.R
@@ -121,14 +121,14 @@ makeContent.errorbarb <- function(grob) {
 #' @export
 create_errorbarb <- function(x, y, height, width, errorbar_tip_size) {
   # validate the input arguments
-  if (height <= 0) {
-    rlang::abort("`height` must be larger than zero.")
+  if (height < 0) {
+    rlang::abort("`height` must be non-negative.")
   }
-  if (width <= 0) {
-    rlang::abort("`width` must be larger than zero.")
+  if (width < 0) {
+    rlang::abort("`width` must be non-negative.")
   }
   if (errorbar_tip_size < 0) {
-    rlang::abort("`errorbar_tip_size` must be larger than zero.")
+    rlang::abort("`errorbar_tip_size` must be non-negative.")
   }
   # calculate coordination of errorbarb
   data.frame(

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -17,3 +17,9 @@ test_that("calc_error uses se when specified", {
   x <- 1:5
   expect_equal(calc_error(x, fun.errorbar = "se"), se(x))
 })
+
+test_that("create_errorbarb allows zero width and height", {
+  errorbar <- create_errorbarb(x = 0, y = 0, height = 0, width = 0, errorbar_tip_size = 1)
+  expect_s3_class(errorbar, "data.frame")
+  expect_equal(nrow(errorbar), 8)
+})


### PR DESCRIPTION
## Summary
- allow zero-length error bar components by relaxing the validation in `create_errorbarb`
- add a regression test to confirm zero width and height are accepted

https://chatgpt.com/codex/tasks/task_e_68ccfcde926883278c241878c8e62f60